### PR TITLE
Changes during greedyman

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -94,6 +94,7 @@ impl Board {
         available_moves
     }
 
+    // Maybe take Plys as parameters for actions?
     pub fn place_piece(&mut self, player_id: i8, piece_id: String) {
         let position = self.get_mut_position(piece_id);
         position.place(player_id);

--- a/src/game/game_state.rs
+++ b/src/game/game_state.rs
@@ -79,9 +79,6 @@ impl GameState {
         game_state.board.perform_mill(piece_id.to_owned(), player_id);
         game_state.ply_to_get_here = Mill {player_id, piece_id};
 
-        let new_player_state = game_state.player_state(player_id).increment_score();
-        game_state.update_player_state(player_id, new_player_state);
-
         give_new_game_state(&mut game_state, player_id);
 
         game_state
@@ -171,6 +168,12 @@ fn give_new_game_state(game_state: &mut GameState, player_id: i8) {
     let can_mill = game_state.can_mill_next(player_id);
     game_state.new_next_ply(player_id, can_mill);
     game_state.current_player_id = game_state.next_ply.player_id();
+
+    // If this is a placement/move that leads to a mill, increment the score
+    if can_mill {
+        let new_player_state = game_state.player_state(player_id).increment_score();
+        game_state.update_player_state(player_id, new_player_state);
+    }
 }
 
 impl fmt::Debug for GameState {

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -37,7 +37,10 @@ impl Game {
     pub fn game_loop(&mut self) -> i8 {
         loop {
             self.print();
+
             self.current_state = self.make_move();
+            self.update_input_handlers();
+
             self.current_state = self.mill();
 
             // Have to check for last player by this point the players have swappeds

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,4 +1,5 @@
 use term_painter::Color::*;
+use term_painter::Painted;
 use term_painter::ToStyle;
 
 mod game_state;
@@ -90,19 +91,23 @@ impl Game {
     }
 
     fn end_game(&self) -> i8 {
-        let winner = self.get_current_player();
-        let loser = self.get_other_player();
-        let winner_name;
-        match winner.id {
-            1 => winner_name = Green.paint(winner.name.to_owned()),
-            2 => winner_name = Blue.paint(winner.name.to_owned()),
-            _ => panic!("Unknown player id: {}", winner.id),
-        }
+        let winner = self.get_other_player();
+        let loser = self.get_current_player();
 
-        println!("Congratulations, {} (Player {})! You win with a score of {}", winner_name, winner.id, self.current_state.player_score(winner.id));
-        println!("Commiserations, {} (Player {}). You lose with a score of {}", loser.name, loser.id, self.current_state.player_score(loser.id));
+        println!("\nCongratulations, {} 🎉 (Player {})! You win with a score of {}",
+            self.colour_player(winner), winner.id, self.current_state.player_score(winner.id));
+        println!("Commiserations, {} 😞 (Player {}). You lose with a score of {}",
+            self.colour_player(loser), loser.id, self.current_state.player_score(loser.id));
 
         winner.id
+    }
+
+    fn colour_player(&self, player: &Player) -> Painted<String> {
+        match player.id {
+            1 => Green.paint(player.name.to_owned()),
+            2 => Blue.paint(player.name.to_owned()),
+            _ => panic!("Unknown player id: {}", player.id),
+        }
     }
 
     fn get_move(&mut self) -> (String, String) {

--- a/src/player/input_handler.rs
+++ b/src/player/input_handler.rs
@@ -1,5 +1,6 @@
 use game::GameState;
 
+// TODO: maybe make InputHandler return Plys instead?
 pub trait InputHandler {
     fn give_new_game_state(&mut self, game: GameState);
     fn get_placement(&mut self, available_places: Vec<String>) -> String;


### PR DESCRIPTION
Main change is that score now incremented if a placement/move ply leads to a mill, rather than if the ply is a mill. This means that `greedyman` or other bots can know if a placement/move will lead to points without looking at two levels of children. In other words, you get points when you create a mill, not when you take a piece.

Other significant change is that player's game states are updated after a placement/move as well as after a mill so that bots can see the current state to use in milling.

The other change is that the end screen now displays properly and looks nicer.